### PR TITLE
resolve logger panic when stderr is a TTY

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ git clone git@github.com:nadgowdas/microservices-demo.git
 
 2. Point topology analyzer to this sample repo
 ```
-$ ./bin/net-top -dirpath $HOME/microservices-demo -commitid 9133fdc043b20be15f958339e96564eac04bed6e -giturl https://github.com/nadgowdas/microservices-demo -gitbranch matser
+$ ./bin/net-top -dirpath $HOME/microservices-demo -commitid 9133fdc043b20be15f958339e96564eac04bed6e -giturl https://github.com/nadgowdas/microservices-demo -gitbranch master
 ```
 
 3. You can expect the result connection in following schema

--- a/cmd/nettop/main.go
+++ b/cmd/nettop/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"errors"
 	"os"
+	"syscall"
 
 	"go.uber.org/zap"
 
@@ -13,7 +15,10 @@ func runAnalysis() int {
 	logger := common.SetupLogger()
 	defer func() {
 		err := logger.Sync()
-		if err != nil {
+		// If stderr is a TTY we might not be able to sync.
+		// See https://github.com/uber-go/zap/issues/991#issuecomment-962098428 for
+		// why we ignore ENOTTY.  On OSX, we must ignore EBADF.
+		if err != nil && !errors.Is(err, syscall.ENOTTY) && !errors.Is(err, syscall.EBADF) {
 			panic(err)
 		}
 	}()


### PR DESCRIPTION
Signed-off-by: Ed Snible <snible@us.ibm.com>

For me, running _net-top_ panics with backtrace unless stderr is redirected.  `net-top` panics; `net-top 2>/tmp/output.txt` does not.

Resolves https://github.com/np-guard/cluster-topology-analyzer/issues/71
Only tested on macOS (OS X)

See https://github.com/uber-go/zap/issues/991#issuecomment-962098428 for rationale.