### PR TITLE
github.ref_name instead of github.ref

### DIFF
--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -30,15 +30,15 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/np-guard/net-top-analyzer:${{ github.ref }}
+          tags: ghcr.io/np-guard/net-top-analyzer:${{ github.ref_name }}
 
       - name: Create a github release
         uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          tag_name: ${{ github.ref_name }}
+          release_name: Release ${{ github.ref_name }}
           body: |
             Changes in this Release:
           draft: false
@@ -50,4 +50,4 @@ jobs:
           go-version: 1.17
 
       - name: Publish on pkg.go.dev
-        run: GOPROXY=proxy.golang.org go list -m github.com/np-guard/cluster-topology-analyzer@${{ github.ref }}
+        run: GOPROXY=proxy.golang.org go list -m github.com/np-guard/cluster-topology-analyzer@${{ github.ref_name }}


### PR DESCRIPTION
Sorry, the previous PR failed to work.
I used `github.ref` which returns something like `refs/tags/v1.3.0`. This string cannot be used as a docker image tag.
Now using `github.ref_name`, which returns just `1.3.0`.

Signed-off-by: Ziv Nevo <nevo@il.ibm.com>