### PR TITLE
Include args parsing in end-to-end testing

### DIFF
--- a/cmd/nettop/main.go
+++ b/cmd/nettop/main.go
@@ -109,16 +109,25 @@ func detectTopology(args *InArgs) error {
 	return nil
 }
 
-func main() {
-	inArgs, err := ParseInArgs()
+// The actual main function
+// Takes command-line flags and returns an error rather than exiting, so it can be more easily used in testing
+func _main(cmdlineArgs []string) error {
+	inArgs, err := ParseInArgs(cmdlineArgs)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error parsing arguments: %v. exiting...\n", err)
-		os.Exit(1)
+		return fmt.Errorf("error parsing arguments: %w", err)
 	}
 
 	err = detectTopology(inArgs)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error running topology analysis: %v. exiting...", err)
+		return fmt.Errorf("error running topology analysis: %w", err)
+	}
+	return nil
+}
+
+func main() {
+	err := _main(os.Args[1:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v. exiting...", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/nettop/main.go
+++ b/cmd/nettop/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"os"
 
@@ -113,6 +114,9 @@ func detectTopology(args *InArgs) error {
 // Takes command-line flags and returns an error rather than exiting, so it can be more easily used in testing
 func _main(cmdlineArgs []string) error {
 	inArgs, err := ParseInArgs(cmdlineArgs)
+	if err == flag.ErrHelp {
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("error parsing arguments: %w", err)
 	}

--- a/cmd/nettop/main.go
+++ b/cmd/nettop/main.go
@@ -67,7 +67,7 @@ func writeContent(outputFile, outputFormat string, content interface{}) error {
 }
 
 // returns verbosity level based on the -q and -v switches
-func getVerbosity(args InArgs) controller.Verbosity {
+func getVerbosity(args *InArgs) controller.Verbosity {
 	verbosity := controller.MediumVerbosity
 	if *args.Quiet {
 		verbosity = controller.LowVerbosity
@@ -80,7 +80,7 @@ func getVerbosity(args InArgs) controller.Verbosity {
 // Based on the arguments it is given, scans all YAML files,
 // detects all required connection between resources and outputs a json connectivity report
 // (or NetworkPolicies to allow only this connectivity)
-func detectTopology(args InArgs) error {
+func detectTopology(args *InArgs) error {
 	logger := controller.NewDefaultLoggerWithVerbosity(getVerbosity(args))
 	synth := controller.NewPoliciesSynthesizer(controller.WithLogger(logger), controller.WithDNSPort(*args.DNSPort))
 
@@ -110,8 +110,7 @@ func detectTopology(args InArgs) error {
 }
 
 func main() {
-	var inArgs InArgs
-	err := ParseInArgs(&inArgs)
+	inArgs, err := ParseInArgs()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error parsing arguments: %v. exiting...\n", err)
 		os.Exit(1)

--- a/cmd/nettop/main_test.go
+++ b/cmd/nettop/main_test.go
@@ -114,6 +114,15 @@ var (
 			[]string{"bookinfo", "expected_netpol_output.json"},
 		},
 		{
+			"HelpFlag",
+			nil,
+			JSONFormat,
+			true,
+			[]string{"-h"},
+			false,
+			nil,
+		},
+		{
 			"BadFlag",
 			[][]string{{"bookinfo"}},
 			JSONFormat,

--- a/cmd/nettop/main_test.go
+++ b/cmd/nettop/main_test.go
@@ -114,6 +114,15 @@ var (
 			[]string{"bookinfo", "expected_netpol_output.json"},
 		},
 		{
+			"SpecifyDNSPort",
+			[][]string{{"acs-security-demos"}},
+			YamlFormat,
+			true,
+			[]string{"-v", "-dnsport", "5353"},
+			false,
+			[]string{"acs-security-demos", "expected_netpol_output.yaml"},
+		},
+		{
 			"HelpFlag",
 			nil,
 			JSONFormat,

--- a/cmd/nettop/main_test.go
+++ b/cmd/nettop/main_test.go
@@ -138,7 +138,7 @@ func (td *TestDetails) runTest(t *testing.T) {
 	require.Nil(t, err)
 
 	args := getTestArgs(td.dirPath, outFileName, td.outputFormat, td.synthNetpols, td.quiet, td.verbose)
-	err = detectTopology(args)
+	err = detectTopology(&args)
 
 	if td.expectError {
 		require.NotNil(t, err)

--- a/cmd/nettop/main_test.go
+++ b/cmd/nettop/main_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/np-guard/cluster-topology-analyzer/pkg/controller"
 )
 
 type TestDetails struct {
@@ -18,8 +16,7 @@ type TestDetails struct {
 	dirPath        [][]string
 	outputFormat   string
 	synthNetpols   bool
-	quiet          bool
-	verbose        bool
+	extraFlags     []string
 	expectError    bool
 	expectedOutput []string
 }
@@ -31,8 +28,7 @@ var (
 			[][]string{{"onlineboutique", "kubernetes-manifests.yaml"}},
 			JSONFormat,
 			false,
-			false,
-			false,
+			nil,
 			false,
 			[]string{"onlineboutique", "expected_output.json"},
 		},
@@ -41,8 +37,7 @@ var (
 			[][]string{{"onlineboutique", "kubernetes-manifests.yaml"}},
 			YamlFormat,
 			false,
-			false,
-			false,
+			nil,
 			false,
 			[]string{"onlineboutique", "expected_output.yaml"},
 		},
@@ -51,8 +46,7 @@ var (
 			[][]string{{"onlineboutique"}},
 			JSONFormat,
 			false,
-			true,
-			false,
+			[]string{"-q"},
 			false,
 			[]string{"onlineboutique", "expected_dirscan_output.json"},
 		},
@@ -61,8 +55,7 @@ var (
 			[][]string{{"onlineboutique", "kubernetes-manifests.yaml"}},
 			YamlFormat,
 			true,
-			false,
-			false,
+			nil,
 			false,
 			[]string{"onlineboutique", "expected_netpol_output.yaml"},
 		},
@@ -71,8 +64,7 @@ var (
 			[][]string{{"k8s_wordpress_example", "mysql-deployment.yaml"}, {"k8s_wordpress_example", "wordpress-deployment.yaml"}},
 			JSONFormat,
 			true,
-			false,
-			false,
+			nil,
 			false,
 			[]string{"k8s_wordpress_example", "expected_netpol_output.json"},
 		},
@@ -81,8 +73,7 @@ var (
 			[][]string{{"onlineboutique", "kubernetes-manifests.yaml"}},
 			JSONFormat,
 			true,
-			false,
-			false,
+			nil,
 			false,
 			[]string{"onlineboutique", "expected_netpol_output.json"},
 		},
@@ -91,8 +82,7 @@ var (
 			[][]string{{"sockshop", "manifests"}},
 			JSONFormat,
 			true,
-			false,
-			true,
+			[]string{"-v"},
 			false,
 			[]string{"sockshop", "expected_netpol_output.json"},
 		},
@@ -101,8 +91,7 @@ var (
 			[][]string{{"k8s_wordpress_example"}},
 			JSONFormat,
 			true,
-			false,
-			true,
+			[]string{"-v"},
 			false,
 			[]string{"k8s_wordpress_example", "expected_netpol_output.json"},
 		},
@@ -111,8 +100,7 @@ var (
 			[][]string{{"k8s_guestbook"}},
 			JSONFormat,
 			true,
-			false,
-			true,
+			[]string{"-v"},
 			false,
 			[]string{"k8s_guestbook", "expected_netpol_output.json"},
 		},
@@ -121,10 +109,63 @@ var (
 			[][]string{{"bookinfo"}},
 			JSONFormat,
 			true,
-			false,
-			true,
+			[]string{"-v"},
 			false,
 			[]string{"bookinfo", "expected_netpol_output.json"},
+		},
+		{
+			"BadFlag",
+			[][]string{{"bookinfo"}},
+			JSONFormat,
+			true,
+			[]string{"-no_such_flag"},
+			true,
+			nil,
+		},
+		{
+			"QuietAndVerbose",
+			[][]string{{"bookinfo"}},
+			JSONFormat,
+			true,
+			[]string{"-q", "-v"},
+			true,
+			nil,
+		},
+		{
+			"BadOutputFormat",
+			[][]string{{"bookinfo"}},
+			"StrangeFormat",
+			true,
+			nil,
+			true,
+			nil,
+		},
+		{
+			"noDirPath",
+			nil,
+			JSONFormat,
+			true,
+			nil,
+			true,
+			nil,
+		},
+		{
+			"badDirPathConnections",
+			[][]string{{"no-such-path"}},
+			JSONFormat,
+			false,
+			nil,
+			true,
+			nil,
+		},
+		{
+			"badDirPathNetpols",
+			[][]string{{"no-such-path"}},
+			JSONFormat,
+			true,
+			nil,
+			true,
+			nil,
 		},
 	}
 
@@ -137,8 +178,7 @@ func (td *TestDetails) runTest(t *testing.T) {
 	outFileName, err := getTempOutputFile()
 	require.Nil(t, err)
 
-	args := getTestArgs(td.dirPath, outFileName, td.outputFormat, td.synthNetpols, td.quiet, td.verbose)
-	err = detectTopology(&args)
+	err = _main(getTestArgs(td, outFileName))
 
 	if td.expectError {
 		require.NotNil(t, err)
@@ -178,20 +218,16 @@ func pathInTestsDir(pathElements []string) string {
 	return filepath.Join(testsDir, filepath.Join(pathElements...))
 }
 
-func getTestArgs(dirPaths [][]string, outFile, outFormat string, netpols, quiet, verbose bool) InArgs {
-	args := InArgs{}
-	args.DirPaths = []string{}
-	for idx := range dirPaths {
-		args.DirPaths = append(args.DirPaths, pathInTestsDir(dirPaths[idx]))
+func getTestArgs(td *TestDetails, outFile string) []string {
+	res := []string{"-outputfile", outFile, "-format", td.outputFormat}
+	if td.synthNetpols {
+		res = append(res, "-netpols")
 	}
-	args.OutputFile = &outFile
-	args.OutputFormat = &outFormat
-	args.SynthNetpols = &netpols
-	args.Quiet = &quiet
-	args.Verbose = &verbose
-	defaultDNSPortNum := controller.DefaultDNSPort
-	args.DNSPort = &defaultDNSPortNum
-	return args
+	for idx := range td.dirPath {
+		res = append(res, "-dirpath", pathInTestsDir(td.dirPath[idx]))
+	}
+	res = append(res, td.extraFlags...)
+	return res
 }
 
 func readLines(path string) ([]string, error) {

--- a/cmd/nettop/parse_args.go
+++ b/cmd/nettop/parse_args.go
@@ -33,16 +33,20 @@ type InArgs struct {
 	Verbose      *bool
 }
 
-func ParseInArgs() (*InArgs, error) {
+func ParseInArgs(cmdlineArgs []string) (*InArgs, error) {
 	args := InArgs{}
-	flag.Var(&args.DirPaths, "dirpath", "input directory path")
-	args.OutputFile = flag.String("outputfile", "", "file path to store results")
-	args.OutputFormat = flag.String("format", JSONFormat, "output format; must be either \"json\" or \"yaml\"")
-	args.SynthNetpols = flag.Bool("netpols", false, "whether to synthesize NetworkPolicies to allow only the discovered connections")
-	args.DNSPort = flag.Int("dnsport", controller.DefaultDNSPort, "specify DNS port to be used in egress rules of synthesized NetworkPolicies")
-	args.Quiet = flag.Bool("q", false, "runs quietly, reports only severe errors and results")
-	args.Verbose = flag.Bool("v", false, "runs with more informative messages printed to log")
-	flag.Parse()
+	flagset := flag.NewFlagSet("cluster-topology-analyzer", flag.ContinueOnError)
+	flagset.Var(&args.DirPaths, "dirpath", "input directory path")
+	args.OutputFile = flagset.String("outputfile", "", "file path to store results")
+	args.OutputFormat = flagset.String("format", JSONFormat, "output format; must be either \"json\" or \"yaml\"")
+	args.SynthNetpols = flagset.Bool("netpols", false, "whether to synthesize NetworkPolicies to allow only the discovered connections")
+	args.DNSPort = flagset.Int("dnsport", controller.DefaultDNSPort, "DNS port to be used in egress rules of synthesized NetworkPolicies")
+	args.Quiet = flagset.Bool("q", false, "runs quietly, reports only severe errors and results")
+	args.Verbose = flagset.Bool("v", false, "runs with more informative messages printed to log")
+	err := flagset.Parse(cmdlineArgs)
+	if err != nil {
+		return nil, err
+	}
 
 	if len(args.DirPaths) == 0 {
 		flag.PrintDefaults()

--- a/cmd/nettop/parse_args.go
+++ b/cmd/nettop/parse_args.go
@@ -49,15 +49,15 @@ func ParseInArgs(cmdlineArgs []string) (*InArgs, error) {
 	}
 
 	if len(args.DirPaths) == 0 {
-		flag.PrintDefaults()
+		flagset.PrintDefaults()
 		return nil, fmt.Errorf("missing parameter: dirpath")
 	}
 	if *args.Quiet && *args.Verbose {
-		flag.PrintDefaults()
+		flagset.PrintDefaults()
 		return nil, fmt.Errorf("-q and -v cannot be specified together")
 	}
 	if *args.OutputFormat != JSONFormat && *args.OutputFormat != YamlFormat {
-		flag.PrintDefaults()
+		flagset.PrintDefaults()
 		return nil, fmt.Errorf("wrong output format %s; must be either json or yaml", *args.OutputFormat)
 	}
 

--- a/cmd/nettop/parse_args.go
+++ b/cmd/nettop/parse_args.go
@@ -33,7 +33,8 @@ type InArgs struct {
 	Verbose      *bool
 }
 
-func ParseInArgs(args *InArgs) error {
+func ParseInArgs() (*InArgs, error) {
+	args := InArgs{}
 	flag.Var(&args.DirPaths, "dirpath", "input directory path")
 	args.OutputFile = flag.String("outputfile", "", "file path to store results")
 	args.OutputFormat = flag.String("format", JSONFormat, "output format; must be either \"json\" or \"yaml\"")
@@ -45,16 +46,16 @@ func ParseInArgs(args *InArgs) error {
 
 	if len(args.DirPaths) == 0 {
 		flag.PrintDefaults()
-		return fmt.Errorf("missing parameter: dirpath")
+		return nil, fmt.Errorf("missing parameter: dirpath")
 	}
 	if *args.Quiet && *args.Verbose {
 		flag.PrintDefaults()
-		return fmt.Errorf("-q and -v cannot be specified together")
+		return nil, fmt.Errorf("-q and -v cannot be specified together")
 	}
 	if *args.OutputFormat != JSONFormat && *args.OutputFormat != YamlFormat {
 		flag.PrintDefaults()
-		return fmt.Errorf("wrong output format %s; must be either json or yaml", *args.OutputFormat)
+		return nil, fmt.Errorf("wrong output format %s; must be either json or yaml", *args.OutputFormat)
 	}
 
-	return nil
+	return &args, nil
 }


### PR DESCRIPTION
Fixes #176 

Also adding end-to-end bad-path testing and testing the new `-dnsport` flag