### PR TITLE
expose to the cluster services pointed by Ingress

### DIFF
--- a/pkg/analyzer/resources.go
+++ b/pkg/analyzer/resources.go
@@ -3,144 +3,16 @@ package analyzer
 import (
 	"io"
 
-	ocroutev1 "github.com/openshift/api/route/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
-
-	appsv1 "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1"
-	v1 "k8s.io/api/core/v1"
-	networkv1 "k8s.io/api/networking/v1"
 )
 
 const yamlParseBufferSize = 200
 
-// parseDeployment parses deployment
-func parseDeployment(r io.Reader) *appsv1.Deployment {
+func parseResource[T interface{}](r io.Reader) *T {
 	if r == nil {
 		return nil
 	}
-	rc := appsv1.Deployment{}
-	err := yaml.NewYAMLOrJSONDecoder(r, yamlParseBufferSize).Decode(&rc)
-	if err != nil {
-		return nil
-	}
-	return &rc
-}
-
-// parseReplicaSet parses replicaset
-func parseReplicaSet(r io.Reader) *appsv1.ReplicaSet {
-	if r == nil {
-		return nil
-	}
-	rc := appsv1.ReplicaSet{}
-	err := yaml.NewYAMLOrJSONDecoder(r, yamlParseBufferSize).Decode(&rc)
-	if err != nil {
-		return nil
-	}
-	return &rc
-}
-
-// parseReplicationController parses replicationController
-func parseReplicationController(r io.Reader) *v1.ReplicationController {
-	if r == nil {
-		return nil
-	}
-	rc := v1.ReplicationController{}
-	err := yaml.NewYAMLOrJSONDecoder(r, yamlParseBufferSize).Decode(&rc)
-	if err != nil {
-		return nil
-	}
-
-	return &rc
-}
-
-// parseDaemonSet parses a DaemonSet resource
-func parseDaemonSet(r io.Reader) *appsv1.DaemonSet {
-	if r == nil {
-		return nil
-	}
-	rc := appsv1.DaemonSet{}
-	err := yaml.NewYAMLOrJSONDecoder(r, yamlParseBufferSize).Decode(&rc)
-	if err != nil {
-		return nil
-	}
-
-	return &rc
-}
-
-// parseStatefulSet parses a StatefulSet resource
-func parseStatefulSet(r io.Reader) *appsv1.StatefulSet {
-	if r == nil {
-		return nil
-	}
-	rc := appsv1.StatefulSet{}
-	err := yaml.NewYAMLOrJSONDecoder(r, yamlParseBufferSize).Decode(&rc)
-	if err != nil {
-		return nil
-	}
-
-	return &rc
-}
-
-// parseJob parses a Job resource
-func parseJob(r io.Reader) *batchv1.Job {
-	if r == nil {
-		return nil
-	}
-	rc := batchv1.Job{}
-	err := yaml.NewYAMLOrJSONDecoder(r, yamlParseBufferSize).Decode(&rc)
-	if err != nil {
-		return nil
-	}
-
-	return &rc
-}
-
-// parseService parses a Service resource
-func parseService(r io.Reader) *v1.Service {
-	if r == nil {
-		return nil
-	}
-	rc := v1.Service{}
-	err := yaml.NewYAMLOrJSONDecoder(r, yamlParseBufferSize).Decode(&rc)
-	if err != nil {
-		return nil
-	}
-	return &rc
-}
-
-// parseRoute parses an OpenShift Route resource
-func parseRoute(r io.Reader) *ocroutev1.Route {
-	if r == nil {
-		return nil
-	}
-	rc := ocroutev1.Route{}
-	err := yaml.NewYAMLOrJSONDecoder(r, yamlParseBufferSize).Decode(&rc)
-	if err != nil {
-		return nil
-	}
-	return &rc
-}
-
-// parseIngress parses an Ingress resource
-func parseIngress(r io.Reader) *networkv1.Ingress {
-	if r == nil {
-		return nil
-	}
-	rc := networkv1.Ingress{}
-	err := yaml.NewYAMLOrJSONDecoder(r, yamlParseBufferSize).Decode(&rc)
-	if err != nil {
-		return nil
-	}
-	return &rc
-}
-
-// parseConfigMap parses a ConfigMap resource
-func parseConfigMap(r io.Reader) *v1.ConfigMap {
-	if r == nil {
-		return nil
-	}
-	rc := v1.ConfigMap{}
+	var rc T
 	err := yaml.NewYAMLOrJSONDecoder(r, yamlParseBufferSize).Decode(&rc)
 	if err != nil {
 		return nil

--- a/pkg/analyzer/resources.go
+++ b/pkg/analyzer/resources.go
@@ -9,6 +9,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
+	networkv1 "k8s.io/api/networking/v1"
 )
 
 const yamlParseBufferSize = 200
@@ -114,6 +115,19 @@ func parseRoute(r io.Reader) *ocroutev1.Route {
 		return nil
 	}
 	rc := ocroutev1.Route{}
+	err := yaml.NewYAMLOrJSONDecoder(r, yamlParseBufferSize).Decode(&rc)
+	if err != nil {
+		return nil
+	}
+	return &rc
+}
+
+// parseIngress parses an Ingress resource
+func parseIngress(r io.Reader) *networkv1.Ingress {
+	if r == nil {
+		return nil
+	}
+	rc := networkv1.Ingress{}
 	err := yaml.NewYAMLOrJSONDecoder(r, yamlParseBufferSize).Decode(&rc)
 	if err != nil {
 		return nil

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -58,3 +58,7 @@ type Connections struct {
 	Target *Resource `json:"target"`
 	Link   *Service  `json:"link"`
 }
+
+// A map from namespaces to a map of service names in each namespaces.
+// For each service we also hold whether they should be exposed externally (true) or just globally inside the cluster (false)
+type ServicesToExpose map[string]map[string]bool

--- a/pkg/controller/policies_synthesizer.go
+++ b/pkg/controller/policies_synthesizer.go
@@ -153,7 +153,7 @@ func (ps *PoliciesSynthesizer) extractConnections(dirPaths []string) ([]*common.
 	if stopProcessing(ps.stopOnError, fileErrors) {
 		return nil, nil, fileErrors
 	}
-	resFinder.exposeServicesWithRoutes()
+	resFinder.exposeServices()
 
 	// 3. Discover all connections between resources
 	connections := discoverConnections(resFinder.workloads, resFinder.services, ps.logger)

--- a/tests/bad_yamls/irrelevant_k8s_resources.yaml
+++ b/tests/bad_yamls/irrelevant_k8s_resources.yaml
@@ -1,25 +1,13 @@
 apiVersion: networking.k8s.io/v1
-kind: Ingress
+kind: IngressClass
 metadata:
-  creationTimestamp: "2022-01-27T18:20:25Z"
-  generation: 3
-  name: testcase26-ingress-policy #-ingress
-  namespace: default
-  resourceVersion: "37135"
-  uid: 85e70fbc-0b4b-462c-9bc1-9a1e7e00db58
+  labels:
+    app.kubernetes.io/component: controller
+  name: nginx-example
+  annotations:
+    ingressclass.kubernetes.io/is-default-class: "true"
 spec:
-  ingressClassName: nginx
-  rules:
-  - host: demo.localdev.me
-    http:
-      paths:
-      - backend:
-          service:
-            name: details
-            port:
-              number: 9080
-        path: /details
-        pathType: Prefix
+  controller: k8s.io/ingress-nginx
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/tests/bookinfo/expected_netpol_output.json
+++ b/tests/bookinfo/expected_netpol_output.json
@@ -128,6 +128,19 @@
                                 "protocol": "TCP",
                                 "port": 9080
                             }
+                        ],
+                        "from": [
+                            {
+                                "namespaceSelector": {}
+                            }
+                        ]
+                    },
+                    {
+                        "ports": [
+                            {
+                                "protocol": "TCP",
+                                "port": 9080
+                            }
                         ]
                     }
                 ],


### PR DESCRIPTION
Fixes #212 

In this PR:
* Scanning Ingress resources and marking the services they point to as `ExposeToCluster=true`
* `resourceFinder` no longer stores Route resources, nor will it store Ingress resources. Instead, it just stores in a dedicated data structure all the services it will have to expose later on. When scanning a Route resource or an Ingress resource, this data structure gets updated with the Services mentioned in the scanned resource.
* Using generics to avoid having a new parse function for every new resource we consider