### PR TITLE
Improved identification of network addresses

### DIFF
--- a/pkg/analyzer/scan.go
+++ b/pkg/analyzer/scan.go
@@ -216,32 +216,31 @@ func appendNetworkAddresses(networkAddresses, values []string) []string {
 
 // NetworkAddressValue tries to extract a network address from the given string.
 // This is a critical step in identifying which service talks to which,
-// because it identifies the evidence for a potentially required connectivity.
+// because it decides if the given string is an evidence for a potentially required connectivity.
 // If it succeeds, a "cleaned" network address is returned as a string, together with the value true.
 // Otherwise (there does not seem to be a network address in "value"), it returns "" with the value false.
 func NetworkAddressValue(value string) (string, bool) {
-	hostname, err := getHostFromURL(value)
+	host, err := getHostFromURL(value)
 	if err != nil {
 		return "", false // value cannot be interpreted as a URL
 	}
 
-	// chop port number (if exists)
-	hostnameNoPort := hostname
-	colonPos := strings.Index(hostname, ":")
+	hostNoPort := host
+	colonPos := strings.Index(host, ":")
 	if colonPos >= 0 {
-		hostnameNoPort = hostname[:colonPos]
+		hostNoPort = host[:colonPos]
 	}
 
-	errs := validation.IsDNS1123Subdomain(hostnameNoPort)
+	errs := validation.IsDNS1123Subdomain(hostNoPort)
 	if len(errs) > 0 {
 		return "", false // host part of the URL is not really a network address
 	}
 
-	_, err = strconv.Atoi(hostnameNoPort)
+	_, err = strconv.Atoi(hostNoPort)
 	if err == nil {
 		return "", false // we do not accept integers as network addresses
 	}
-	return hostname, true
+	return host, true
 }
 
 // Attempts to parse the given string as a URL, and extract its Host part.
@@ -252,10 +251,10 @@ func getHostFromURL(urlStr string) (string, error) {
 		return "", err
 	}
 
-	if parsedURL.Host == "" {
+	if parsedURL.Host == "" { // URL looks like scheme:opaque[?query][#fragment]
 		parsedURL.Fragment = ""
 		parsedURL.RawQuery = ""
-		return parsedURL.String(), nil // URL looks like scheme:opaque[?query][#fragment]
+		return parsedURL.String(), nil
 	}
 
 	// URL looks like [scheme:][//[userinfo@]host][/]path[?query][#fragment]

--- a/pkg/controller/connections.go
+++ b/pkg/controller/connections.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/np-guard/cluster-topology-analyzer/pkg/common"
 )
@@ -99,9 +98,6 @@ func getPossibleServiceAddresses(service *common.Service, resource *common.Resou
 }
 
 func envValueMatchesService(envVal string, service *common.Service, serviceAddresses []string) (bool, common.SvcNetworkAttr) {
-	envVal = strings.TrimPrefix(envVal, "http://")
-	envVal = strings.TrimPrefix(envVal, "https://")
-
 	// first look for matches without specified port
 	for _, svcAddress := range serviceAddresses {
 		if svcAddress == envVal {

--- a/pkg/controller/resource_finder.go
+++ b/pkg/controller/resource_finder.go
@@ -242,8 +242,8 @@ func (rf *resourceFinder) inlineConfigMapRefsAsEnvs() []FileProcessingError {
 			configmapFullName := res.Resource.Namespace + "/" + cfgMapRef
 			if cfgMap, ok := cfgMapsByName[configmapFullName]; ok {
 				for _, v := range cfgMap.Data {
-					if analyzer.IsNetworkAddressValue(v) {
-						res.Resource.NetworkAddrs = append(res.Resource.NetworkAddrs, v)
+					if netAddr, ok := analyzer.NetworkAddressValue(v); ok {
+						res.Resource.NetworkAddrs = append(res.Resource.NetworkAddrs, netAddr)
 					}
 				}
 			} else {
@@ -256,8 +256,8 @@ func (rf *resourceFinder) inlineConfigMapRefsAsEnvs() []FileProcessingError {
 			configmapFullName := res.Resource.Namespace + "/" + cfgMapKeyRef.Name
 			if cfgMap, ok := cfgMapsByName[configmapFullName]; ok {
 				if val, ok := cfgMap.Data[cfgMapKeyRef.Key]; ok {
-					if analyzer.IsNetworkAddressValue(val) {
-						res.Resource.NetworkAddrs = append(res.Resource.NetworkAddrs, val)
+					if netAddr, ok := analyzer.NetworkAddressValue(val); ok {
+						res.Resource.NetworkAddrs = append(res.Resource.NetworkAddrs, netAddr)
 					}
 				} else {
 					err := configMapKeyNotFound(cfgMapKeyRef.Name, cfgMapKeyRef.Key, res.Resource.Name)

--- a/tests/bookinfo/expected_netpol_output.json
+++ b/tests/bookinfo/expected_netpol_output.json
@@ -59,6 +59,26 @@
                         "version": "v1"
                     }
                 },
+                "ingress": [
+                    {
+                        "ports": [
+                            {
+                                "protocol": "TCP",
+                                "port": 27017
+                            }
+                        ],
+                        "from": [
+                            {
+                                "podSelector": {
+                                    "matchLabels": {
+                                        "app": "ratings",
+                                        "version": "v2"
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ],
                 "policyTypes": [
                     "Ingress",
                     "Egress"
@@ -186,6 +206,39 @@
                         "version": "v2"
                     }
                 },
+                "egress": [
+                    {
+                        "ports": [
+                            {
+                                "protocol": "TCP",
+                                "port": 27017
+                            }
+                        ],
+                        "to": [
+                            {
+                                "podSelector": {
+                                    "matchLabels": {
+                                        "app": "mongodb",
+                                        "version": "v1"
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "ports": [
+                            {
+                                "protocol": "UDP",
+                                "port": 53
+                            }
+                        ],
+                        "to": [
+                            {
+                                "namespaceSelector": {}
+                            }
+                        ]
+                    }
+                ],
                 "policyTypes": [
                     "Ingress",
                     "Egress"

--- a/tests/onlineboutique/kubernetes-manifests.yaml
+++ b/tests/onlineboutique/kubernetes-manifests.yaml
@@ -86,9 +86,14 @@ spec:
         app: checkoutservice
     spec:
       serviceAccountName: default
+      volumes:
+      - configMap:
+          optional: true
+          name: cart-service-config
       containers:
         - name: server
           image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.2.3
+          command: ["-currencyserviceAddr", "currencyservice:7000"]
           ports:
           - containerPort: 5050
           readinessProbe:
@@ -111,10 +116,6 @@ spec:
             value: "paymentservice:50051"
           - name: EMAIL_SERVICE_ADDR
             value: "emailservice:5000"
-          - name: CURRENCY_SERVICE_ADDR
-            value: "currencyservice:7000"
-          - name: CART_SERVICE_ADDR
-            value: "cartservice:7070"
           # - name: DISABLE_STATS
           #   value: "1"
           # - name: DISABLE_TRACING
@@ -733,3 +734,10 @@ metadata:
   name: shipping-service-config
 data:
   SHIPPING_SERVICE_ADDR: shippingservice:50051
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cart-service-config
+data:
+  CART_SERVICE_ADDR: cartservice:7070


### PR DESCRIPTION
Fixes #216 
Scans `container[i].command` and `volumes[i].configMap`.


Also in this PR:
* Better filtering of potential network addresses
* Storing in each workload only clean network addresses (e.g., removing scheme and path from URLs). This actually identified one more connection in the bookinfo example, where the URL was `mongodb://mongodb:27017/test`