### PR TITLE
Testing for the analyzer package

### DIFF
--- a/pkg/analyzer/resources.go
+++ b/pkg/analyzer/resources.go
@@ -7,19 +7,20 @@ SPDX-License-Identifier: Apache-2.0
 package analyzer
 
 import (
-	"io"
+	"bytes"
 
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
 const yamlParseBufferSize = 200
 
-func parseResource[T interface{}](r io.Reader) *T {
-	if r == nil {
+func parseResource[T interface{}](objDataBuf []byte) *T {
+	reader := bytes.NewReader(objDataBuf)
+	if reader == nil {
 		return nil
 	}
 	var rc T
-	err := yaml.NewYAMLOrJSONDecoder(r, yamlParseBufferSize).Decode(&rc)
+	err := yaml.NewYAMLOrJSONDecoder(reader, yamlParseBufferSize).Decode(&rc)
 	if err != nil {
 		return nil
 	}

--- a/pkg/analyzer/scan_test.go
+++ b/pkg/analyzer/scan_test.go
@@ -1,0 +1,32 @@
+package analyzer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNetworkAddressValue(t *testing.T) {
+
+	type strBoolPair struct {
+		str string
+		b   bool
+	}
+
+	valuesToCheck := map[string]strBoolPair{
+		"svc":                          {"svc", true},
+		"svc:500":                      {"svc:500", true},
+		"http://svc:500":               {"svc:500", true},
+		"http://svc:500/something#abc": {"svc:500", true},
+		strings.Repeat("abc", 500):     {"", false},
+		"not%a*url":                    {"", false},
+		"123":                          {"", false},
+	}
+
+	for val, expectedAnswer := range valuesToCheck {
+		strRes, boolRes := NetworkAddressValue(val)
+		require.Equal(t, expectedAnswer.b, boolRes)
+		require.Equal(t, expectedAnswer.str, strRes)
+	}
+}

--- a/pkg/analyzer/scan_test.go
+++ b/pkg/analyzer/scan_test.go
@@ -74,6 +74,7 @@ func TestScanningDeploymentWithConfigMapRef(t *testing.T) {
 	res, err := ScanK8sWorkloadObject("Deployment", resourceBuf)
 	require.Nil(t, err)
 	require.Equal(t, "webapp", res.Resource.Name)
+	require.Len(t, res.Resource.ConfigMapRefs, 1)
 	require.Empty(t, res.Resource.NetworkAddrs) // extracting network addresses from configmaps happens later
 	require.Len(t, res.Resource.Labels, 1)
 }

--- a/pkg/analyzer/scan_test.go
+++ b/pkg/analyzer/scan_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestNetworkAddressValue(t *testing.T) {
-
 	type strBoolPair struct {
 		str string
 		b   bool

--- a/pkg/analyzer/scan_test.go
+++ b/pkg/analyzer/scan_test.go
@@ -1,10 +1,14 @@
 package analyzer
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/np-guard/cluster-topology-analyzer/pkg/common"
 )
 
 func TestNetworkAddressValue(t *testing.T) {
@@ -15,13 +19,13 @@ func TestNetworkAddressValue(t *testing.T) {
 	}
 
 	valuesToCheck := map[string]strBoolPair{
-		"svc":                          {"svc", true},
-		"svc:500":                      {"svc:500", true},
-		"http://svc:500":               {"svc:500", true},
-		"http://svc:500/something#abc": {"svc:500", true},
-		strings.Repeat("abc", 500):     {"", false},
-		"not%a*url":                    {"", false},
-		"123":                          {"", false},
+		"svc":                           {"svc", true},
+		"svc:500":                       {"svc:500", true},
+		"http://svc:500":                {"svc:500", true},
+		"fttps://svc:500/something#abc": {"svc:500", true},
+		strings.Repeat("abc", 500):      {"", false},
+		"not%a*url":                     {"", false},
+		"123":                           {"", false},
 	}
 
 	for val, expectedAnswer := range valuesToCheck {
@@ -29,4 +33,91 @@ func TestNetworkAddressValue(t *testing.T) {
 		require.Equal(t, expectedAnswer.b, boolRes)
 		require.Equal(t, expectedAnswer.str, strRes)
 	}
+}
+
+func TestScanningSvc(t *testing.T) {
+	resourceBuf, err := loadResourceAsByteArray([]string{"k8s_guestbook", "frontend-service.yaml"})
+	require.Nil(t, err)
+	res, err := ScanK8sServiceObject(resourceBuf)
+	require.Nil(t, err)
+	require.Equal(t, "frontend", res.Resource.Name)
+	require.Len(t, res.Resource.Selectors, 2)
+	require.Len(t, res.Resource.Network, 1)
+	require.Equal(t, 80, res.Resource.Network[0].Port)
+}
+
+func TestScanningDeploymentWithArgs(t *testing.T) {
+	resourceBuf, err := loadResourceAsByteArray([]string{"sockshop", "manifests", "01-carts-dep.yaml"})
+	require.Nil(t, err)
+	res, err := ScanK8sWorkloadObject("Deployment", resourceBuf)
+	require.Nil(t, err)
+	require.Equal(t, "carts", res.Resource.Name)
+	require.Len(t, res.Resource.NetworkAddrs, 1)
+	require.Equal(t, "carts-db:27017", res.Resource.NetworkAddrs[0])
+	require.Len(t, res.Resource.Labels, 1)
+	require.Equal(t, "carts", res.Resource.Labels["name"])
+}
+
+func TestScanningDeploymentWithEnvs(t *testing.T) {
+	resourceBuf, err := loadResourceAsByteArray([]string{"k8s_guestbook", "frontend-deployment.yaml"})
+	require.Nil(t, err)
+	res, err := ScanK8sWorkloadObject("Deployment", resourceBuf)
+	require.Nil(t, err)
+	require.Equal(t, "frontend", res.Resource.Name)
+	require.Len(t, res.Resource.NetworkAddrs, 4)
+	require.Len(t, res.Resource.Labels, 2)
+}
+
+func TestScanningDeploymentWithConfigMapRef(t *testing.T) {
+	resourceBuf, err := loadResourceAsByteArray([]string{"acs-security-demos", "frontend", "webapp", "deployment.yaml"})
+	require.Nil(t, err)
+	res, err := ScanK8sWorkloadObject("Deployment", resourceBuf)
+	require.Nil(t, err)
+	require.Equal(t, "webapp", res.Resource.Name)
+	require.Empty(t, res.Resource.NetworkAddrs) // extracting network addresses from configmaps happens later
+	require.Len(t, res.Resource.Labels, 1)
+}
+
+func TestScanningReplicaSet(t *testing.T) {
+	resourceBuf, err := loadResourceAsByteArray([]string{"k8s_guestbook", "redis-leader-deployment.yaml"})
+	require.Nil(t, err)
+	res, err := ScanK8sWorkloadObject("ReplicaSet", resourceBuf)
+	require.Nil(t, err)
+	require.Equal(t, "redis-leader", res.Resource.Name)
+	require.Len(t, res.Resource.NetworkAddrs, 0)
+	require.Len(t, res.Resource.Labels, 3)
+}
+
+func TestScanningConfigMap(t *testing.T) {
+	resourceBuf, err := loadResourceAsByteArray([]string{"qotd", "qotd_usecase.yaml"})
+	require.Nil(t, err)
+	res, err := ScanK8sConfigmapObject(resourceBuf)
+	require.Nil(t, err)
+	require.Equal(t, res.FullName, "qotd-load/qotd-usecase-library")
+	require.Len(t, res.Data, 5)
+}
+
+func TestScanningIngress(t *testing.T) {
+	resourceBuf, err := loadResourceAsByteArray([]string{"bookinfo", "bookinfo-ingress.yaml"})
+	require.Nil(t, err)
+	toExpose := common.ServicesToExpose{}
+	err = ScanIngressObject(resourceBuf, toExpose)
+	require.Nil(t, err)
+	require.Len(t, toExpose, 1)
+}
+
+func TestScanningRoute(t *testing.T) {
+	resourceBuf, err := loadResourceAsByteArray([]string{"acs-security-demos", "frontend", "webapp", "route.yaml"})
+	require.Nil(t, err)
+	toExpose := common.ServicesToExpose{}
+	err = ScanOCRouteObject(resourceBuf, toExpose)
+	require.Nil(t, err)
+	require.Len(t, toExpose, 1)
+}
+
+func loadResourceAsByteArray(resourceDirs []string) ([]byte, error) {
+	currentDir, _ := os.Getwd()
+	resourceRelPath := filepath.Join(resourceDirs...)
+	resourcePath := filepath.Join(currentDir, "..", "..", "tests", resourceRelPath)
+	return os.ReadFile(resourcePath)
 }

--- a/pkg/controller/resource_finder.go
+++ b/pkg/controller/resource_finder.go
@@ -186,24 +186,24 @@ func (rf *resourceFinder) parseK8sYaml(mfp, relMfp string) []FileProcessingError
 func (rf *resourceFinder) parseResource(kind string, yamlDoc []byte, manifestFilePath string) error {
 	switch kind {
 	case service:
-		res, err := analyzer.ScanK8sServiceObject(kind, yamlDoc)
+		res, err := analyzer.ScanK8sServiceObject(yamlDoc)
 		if err != nil {
 			return err
 		}
 		res.Resource.FilePath = manifestFilePath
 		rf.services = append(rf.services, res)
 	case route:
-		err := analyzer.ScanOCRouteObject(kind, yamlDoc, rf.servicesToExpose)
+		err := analyzer.ScanOCRouteObject(yamlDoc, rf.servicesToExpose)
 		if err != nil {
 			return err
 		}
 	case ingress:
-		err := analyzer.ScanIngressObject(kind, yamlDoc, rf.servicesToExpose)
+		err := analyzer.ScanIngressObject(yamlDoc, rf.servicesToExpose)
 		if err != nil {
 			return err
 		}
 	case configmap:
-		res, err := analyzer.ScanK8sConfigmapObject(kind, yamlDoc)
+		res, err := analyzer.ScanK8sConfigmapObject(yamlDoc)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
As specified in #74 

Also in the PR:
* Not passing resource kind to scan functions, unless it is needed
* `parseResource` now takes a byte-array and builds a bytes-reader, to avoid code duplication