### PR TITLE
Separate dir scanning class

### DIFF
--- a/pkg/analyzer/manifest_finder.go
+++ b/pkg/analyzer/manifest_finder.go
@@ -21,9 +21,28 @@ type manifestFinder struct {
 	walkFn       WalkFunction // for customizing directory scan
 }
 
-// searchForManifests returns a list of YAML files under a given directory.
+// searchForManifestsInDirs is a convenience function to call searchForManifestsInDir() for each path in a slice of dir paths
+func (mf *manifestFinder) searchForManifestsInDirs(dirPaths []string) ([]string, []FileProcessingError) {
+	manifestFiles := []string{}
+	fileErrors := []FileProcessingError{}
+	for _, dirPath := range dirPaths {
+		manifests, errs := mf.searchForManifestsInDir(dirPath)
+		manifestFiles = append(manifestFiles, manifests...)
+		fileErrors = append(fileErrors, errs...)
+		if stopProcessing(mf.stopOn1stErr, errs) {
+			return nil, fileErrors
+		}
+
+		if len(manifestFiles) == 0 {
+			fileErrors = appendAndLogNewError(fileErrors, noYamlsFound(), mf.logger)
+		}
+	}
+	return manifestFiles, fileErrors
+}
+
+// searchForManifestsInDir returns a list of YAML files under a given directory.
 // Directory is scanned using the configured walk function
-func (mf *manifestFinder) searchForManifests(repoDir string) ([]string, []FileProcessingError) {
+func (mf *manifestFinder) searchForManifestsInDir(repoDir string) ([]string, []FileProcessingError) {
 	yamls := []string{}
 	errors := []FileProcessingError{}
 	err := mf.walkFn(repoDir, func(path string, f os.DirEntry, err error) error {

--- a/pkg/analyzer/manifest_finder.go
+++ b/pkg/analyzer/manifest_finder.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2020- IBM Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package analyzer
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+var yamlSuffix = regexp.MustCompile(".ya?ml$")
+
+// manifestFinder is a utility class for searching for YAML files
+type manifestFinder struct {
+	logger       Logger
+	stopOn1stErr bool
+	walkFn       WalkFunction // for customizing directory scan
+}
+
+// searchForManifests returns a list of YAML files under a given directory.
+// Directory is scanned using the configured walk function
+func (mf *manifestFinder) searchForManifests(repoDir string) ([]string, []FileProcessingError) {
+	yamls := []string{}
+	errors := []FileProcessingError{}
+	err := mf.walkFn(repoDir, func(path string, f os.DirEntry, err error) error {
+		if err != nil {
+			errors = appendAndLogNewError(errors, failedAccessingDir(path, err, path != repoDir), mf.logger)
+			if stopProcessing(mf.stopOn1stErr, errors) {
+				return err
+			}
+			return filepath.SkipDir
+		}
+		if f != nil && !f.IsDir() && yamlSuffix.MatchString(f.Name()) {
+			yamls = append(yamls, path)
+		}
+		return nil
+	})
+	if err != nil {
+		mf.logger.Errorf(err, "Error walking directory: %v", err)
+	}
+	return yamls, errors
+}

--- a/pkg/analyzer/manifest_finder_test.go
+++ b/pkg/analyzer/manifest_finder_test.go
@@ -64,3 +64,13 @@ func TestSearchForManifestsMultipleDirsWithErrors(t *testing.T) {
 	require.True(t, errors.As(errs[0].Error(), &badDir))
 	require.Empty(t, yamlFiles)
 }
+
+func TestNoYamlsInDir(t *testing.T) {
+	dirPath := filepath.Join(getTestsDir(), "bad_yamls", "subdir2")
+	manFinder := manifestFinder{NewDefaultLogger(), false, filepath.WalkDir}
+	yamlFiles, errs := manFinder.searchForManifestsInDirs([]string{dirPath})
+	require.Len(t, errs, 1)
+	noYamls := &NoYamlsFoundError{}
+	require.True(t, errors.As(errs[0].Error(), &noYamls))
+	require.Empty(t, yamlFiles)
+}

--- a/pkg/analyzer/manifest_finder_test.go
+++ b/pkg/analyzer/manifest_finder_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2020- IBM Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package analyzer
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSearchForManifests(t *testing.T) {
+	dirPath := filepath.Join(getTestsDir(), "bad_yamls")
+	manFinder := manifestFinder{NewDefaultLogger(), false, filepath.WalkDir}
+	yamlFiles, errs := manFinder.searchForManifests(dirPath)
+	require.Empty(t, errs)
+	require.Len(t, yamlFiles, 5)
+}
+
+func nonRecursiveWalk(root string, fn fs.WalkDirFunc) error {
+	err := filepath.WalkDir(root, func(path string, f os.DirEntry, err error) error {
+		if err != nil {
+			return filepath.SkipDir
+		}
+		if f == nil || path != root && f.IsDir() {
+			return filepath.SkipDir
+		}
+		return fn(path, f, err)
+	})
+	return err
+}
+
+func TestSearchForManifestsNonRecursiveWalk(t *testing.T) {
+	dirPath := filepath.Join(getTestsDir(), "bad_yamls")
+	manFinder := manifestFinder{NewDefaultLogger(), false, nonRecursiveWalk}
+	yamlFiles, errs := manFinder.searchForManifests(dirPath)
+	require.Empty(t, errs)
+	require.Len(t, yamlFiles, 4)
+}

--- a/pkg/analyzer/policies_synthesizer.go
+++ b/pkg/analyzer/policies_synthesizer.go
@@ -168,17 +168,7 @@ func (ps *PoliciesSynthesizer) ConnectionsFromFolderPaths(dirPaths []string) ([]
 func (ps *PoliciesSynthesizer) extractConnectionsFromInfos(infos []*resource.Info) (
 	[]*Resource, []*Connections, []FileProcessingError) {
 	resAcc := newResourceAccumulator(ps.logger, ps.stopOnError, ps.walkFn)
-	fileErrors := []FileProcessingError{}
-	for _, info := range infos {
-		err := resAcc.parseInfo(info)
-		if err != nil {
-			kind := "<unknown>"
-			if info != nil && info.Object != nil {
-				kind = info.Object.GetObjectKind().GroupVersionKind().Kind
-			}
-			fileErrors = appendAndLogNewError(fileErrors, failedScanningResource(kind, info.Source, err), ps.logger)
-		}
-	}
+	fileErrors := resAcc.parseInfos(infos)
 
 	wls, conns, errs := ps.extractConnections(resAcc)
 	fileErrors = append(fileErrors, errs...)

--- a/pkg/analyzer/policies_synthesizer.go
+++ b/pkg/analyzer/policies_synthesizer.go
@@ -168,11 +168,14 @@ func (ps *PoliciesSynthesizer) ConnectionsFromFolderPaths(dirPaths []string) ([]
 func (ps *PoliciesSynthesizer) extractConnectionsFromInfos(infos []*resource.Info) (
 	[]*Resource, []*Connections, []FileProcessingError) {
 	resAcc := newResourceAccumulator(ps.logger, ps.stopOnError)
-	fileErrors := resAcc.parseInfos(infos)
+	parseErrors := resAcc.parseInfos(infos)
+	if stopProcessing(ps.stopOnError, parseErrors) {
+		return nil, nil, parseErrors
+	}
 
 	wls, conns, errs := ps.extractConnections(resAcc)
-	fileErrors = append(fileErrors, errs...)
-	return wls, conns, fileErrors
+	errs = append(parseErrors, errs...)
+	return wls, conns, errs
 }
 
 // Scans the given directories for YAMLs with k8s resources and extracts required connections between workloads

--- a/pkg/analyzer/policies_synthesizer.go
+++ b/pkg/analyzer/policies_synthesizer.go
@@ -167,7 +167,7 @@ func (ps *PoliciesSynthesizer) ConnectionsFromFolderPaths(dirPaths []string) ([]
 
 func (ps *PoliciesSynthesizer) extractConnectionsFromInfos(infos []*resource.Info) (
 	[]*Resource, []*Connections, []FileProcessingError) {
-	resAcc := newResourceAccumulator(ps.logger, ps.stopOnError, ps.walkFn)
+	resAcc := newResourceAccumulator(ps.logger, ps.stopOnError)
 	fileErrors := resAcc.parseInfos(infos)
 
 	wls, conns, errs := ps.extractConnections(resAcc)
@@ -186,7 +186,7 @@ func (ps *PoliciesSynthesizer) extractConnectionsFromFolderPaths(dirPaths []stri
 	}
 
 	// Parse YAMLs and extract relevant resources
-	resAcc := newResourceAccumulator(ps.logger, ps.stopOnError, ps.walkFn)
+	resAcc := newResourceAccumulator(ps.logger, ps.stopOnError)
 	parseErrors := resAcc.parseK8sYamls(manifestFiles)
 	fileErrors = append(fileErrors, parseErrors...)
 	if stopProcessing(ps.stopOnError, fileErrors) {

--- a/pkg/analyzer/policies_synthesizer.go
+++ b/pkg/analyzer/policies_synthesizer.go
@@ -167,10 +167,10 @@ func (ps *PoliciesSynthesizer) ConnectionsFromFolderPaths(dirPaths []string) ([]
 
 func (ps *PoliciesSynthesizer) extractConnectionsFromInfos(infos []*resource.Info) (
 	[]*Resource, []*Connections, []FileProcessingError) {
-	resFinder := newResourceFinder(ps.logger, ps.stopOnError, ps.walkFn)
+	resAcc := newResourceAccumulator(ps.logger, ps.stopOnError, ps.walkFn)
 	fileErrors := []FileProcessingError{}
 	for _, info := range infos {
-		err := resFinder.parseInfo(info)
+		err := resAcc.parseInfo(info)
 		if err != nil {
 			kind := "<unknown>"
 			if info != nil && info.Object != nil {
@@ -180,7 +180,7 @@ func (ps *PoliciesSynthesizer) extractConnectionsFromInfos(infos []*resource.Inf
 		}
 	}
 
-	wls, conns, errs := ps.extractConnections(resFinder)
+	wls, conns, errs := ps.extractConnections(resAcc)
 	fileErrors = append(fileErrors, errs...)
 	return wls, conns, fileErrors
 }
@@ -188,37 +188,37 @@ func (ps *PoliciesSynthesizer) extractConnectionsFromInfos(infos []*resource.Inf
 // Scans the given directory for YAMLs with k8s resources and extracts required connections between workloads
 func (ps *PoliciesSynthesizer) extractConnectionsFromFolderPaths(dirPaths []string) (
 	[]*Resource, []*Connections, []FileProcessingError) {
-	resFinder := newResourceFinder(ps.logger, ps.stopOnError, ps.walkFn)
+	resAcc := newResourceAccumulator(ps.logger, ps.stopOnError, ps.walkFn)
 	fileErrors := []FileProcessingError{}
 	for _, dirPath := range dirPaths {
-		errs := resFinder.getRelevantK8sResources(dirPath)
+		errs := resAcc.getRelevantK8sResources(dirPath)
 		fileErrors = append(fileErrors, errs...)
 		if stopProcessing(ps.stopOnError, errs) {
 			return nil, nil, fileErrors
 		}
 	}
-	wls, conns, errs := ps.extractConnections(resFinder)
+	wls, conns, errs := ps.extractConnections(resAcc)
 	fileErrors = append(fileErrors, errs...)
 	return wls, conns, fileErrors
 }
 
-func (ps *PoliciesSynthesizer) extractConnections(resFinder *resourceFinder) (
+func (ps *PoliciesSynthesizer) extractConnections(resAcc *resourceAccumulator) (
 	[]*Resource, []*Connections, []FileProcessingError) {
-	if len(resFinder.workloads) == 0 {
+	if len(resAcc.workloads) == 0 {
 		return nil, nil, appendAndLogNewError(nil, noK8sResourcesFound(), ps.logger)
 	}
 
 	// Inline configmaps values as workload envs
-	fileErrors := resFinder.inlineConfigMapRefsAsEnvs()
+	fileErrors := resAcc.inlineConfigMapRefsAsEnvs()
 	if stopProcessing(ps.stopOnError, fileErrors) {
 		return nil, nil, fileErrors
 	}
 
-	resFinder.exposeServices()
+	resAcc.exposeServices()
 
 	// Discover all connections between resources
-	connections := discoverConnections(resFinder.workloads, resFinder.services, ps.logger)
-	return resFinder.workloads, connections, fileErrors
+	connections := discoverConnections(resAcc.workloads, resAcc.services, ps.logger)
+	return resAcc.workloads, connections, fileErrors
 }
 
 func hasFatalError(errs []FileProcessingError) error {

--- a/pkg/analyzer/resource_accumulator.go
+++ b/pkg/analyzer/resource_accumulator.go
@@ -64,7 +64,7 @@ func newResourceAccumulator(logger Logger, failFast bool, walkFn WalkFunction) *
 // The resources are stored in the struct, separated to workloads, services and configmaps
 func (ra *resourceAccumulator) getRelevantK8sResources(repoDir string) []FileProcessingError {
 	mf := manifestFinder{ra.logger, ra.stopOn1stErr, ra.walkFn}
-	manifestFiles, fileScanErrors := mf.searchForManifests(repoDir)
+	manifestFiles, fileScanErrors := mf.searchForManifestsInDir(repoDir)
 	if stopProcessing(ra.stopOn1stErr, fileScanErrors) {
 		return fileScanErrors
 	}
@@ -105,7 +105,6 @@ func (ra *resourceAccumulator) parseK8sYaml(mfp string) []FileProcessingError {
 
 	moreErrors := ra.parseInfos(infos)
 	return append(parseErrors, moreErrors...)
-
 }
 
 // A convenience function to call parseInfo() on multiple Info objects

--- a/pkg/analyzer/resource_accumulator.go
+++ b/pkg/analyzer/resource_accumulator.go
@@ -42,7 +42,6 @@ var (
 type resourceAccumulator struct {
 	logger       Logger
 	stopOn1stErr bool
-	walkFn       WalkFunction // for customizing directory scan
 
 	workloads        []*Resource      // accumulates all workload resources found
 	services         []*Service       // accumulates all service resources found
@@ -50,8 +49,8 @@ type resourceAccumulator struct {
 	servicesToExpose servicesToExpose // stores which services should be later exposed
 }
 
-func newResourceAccumulator(logger Logger, failFast bool, walkFn WalkFunction) *resourceAccumulator {
-	res := resourceAccumulator{logger: logger, stopOn1stErr: failFast, walkFn: walkFn}
+func newResourceAccumulator(logger Logger, failFast bool) *resourceAccumulator {
+	res := resourceAccumulator{logger: logger, stopOn1stErr: failFast}
 
 	res.servicesToExpose = servicesToExpose{}
 

--- a/pkg/analyzer/resource_accumulator.go
+++ b/pkg/analyzer/resource_accumulator.go
@@ -58,25 +58,6 @@ func newResourceAccumulator(logger Logger, failFast bool, walkFn WalkFunction) *
 	return &res
 }
 
-// getRelevantK8sResources is the main function of resourceAccumulator.
-// It scans a given directory using walkFn, looking for all yaml files. It then breaks each yaml into its documents
-// and extracts all K8s resources that are relevant for connectivity analysis.
-// The resources are stored in the struct, separated to workloads, services and configmaps
-func (ra *resourceAccumulator) getRelevantK8sResources(repoDir string) []FileProcessingError {
-	mf := manifestFinder{ra.logger, ra.stopOn1stErr, ra.walkFn}
-	manifestFiles, fileScanErrors := mf.searchForManifestsInDir(repoDir)
-	if stopProcessing(ra.stopOn1stErr, fileScanErrors) {
-		return fileScanErrors
-	}
-	if len(manifestFiles) == 0 {
-		fileScanErrors = appendAndLogNewError(fileScanErrors, noYamlsFound(), ra.logger)
-		return fileScanErrors
-	}
-
-	parseErrors := ra.parseK8sYamls(manifestFiles)
-	return append(fileScanErrors, parseErrors...)
-}
-
 // A convenience function to call parseK8sYaml() on multiple YAML paths
 func (ra *resourceAccumulator) parseK8sYamls(yamlPaths []string) []FileProcessingError {
 	parseErrors := []FileProcessingError{}

--- a/pkg/analyzer/resource_accumulator.go
+++ b/pkg/analyzer/resource_accumulator.go
@@ -8,7 +8,6 @@ package analyzer
 
 import (
 	"fmt"
-	"path/filepath"
 	"regexp"
 
 	"k8s.io/cli-runtime/pkg/resource"
@@ -162,19 +161,6 @@ func (rf *resourceAccumulator) parseInfo(info *resource.Info) error {
 	}
 
 	return nil
-}
-
-// returns a file path without its prefix base dir
-func pathWithoutBaseDir(path, baseDir string) string {
-	if path == baseDir { // baseDir is actually a file...
-		return filepath.Base(path) // return just the file name
-	}
-
-	relPath, err := filepath.Rel(baseDir, path)
-	if err != nil {
-		return path
-	}
-	return relPath
 }
 
 // inlineConfigMapRefsAsEnvs appends to the Envs of each given resource the ConfigMap values it is referring to

--- a/pkg/analyzer/resource_accumulator_test.go
+++ b/pkg/analyzer/resource_accumulator_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestGetRelevantK8sResourcesBadYamlDocument(t *testing.T) {
 	dirPath := filepath.Join(getTestsDir(), "bad_yamls", "document_with_syntax_error.yaml")
-	resFinder := newResourceFinder(NewDefaultLogger(), false, filepath.WalkDir)
+	resFinder := newResourceAccumulator(NewDefaultLogger(), false, filepath.WalkDir)
 	errs := resFinder.getRelevantK8sResources(dirPath)
 	require.Len(t, errs, 1)
 	badFile := &FailedReadingFileError{}
@@ -31,7 +31,7 @@ func TestGetRelevantK8sResourcesBadYamlDocument(t *testing.T) {
 
 func TestGetRelevantK8sResourcesBadYamlDocumentFailFast(t *testing.T) {
 	dirPath := filepath.Join(getTestsDir(), "bad_yamls", "document_with_syntax_error.yaml")
-	resFinder := newResourceFinder(NewDefaultLogger(), true, filepath.WalkDir)
+	resFinder := newResourceAccumulator(NewDefaultLogger(), true, filepath.WalkDir)
 	errs := resFinder.getRelevantK8sResources(dirPath)
 	require.Len(t, errs, 1)
 	badFile := &FailedReadingFileError{}
@@ -44,7 +44,7 @@ func TestGetRelevantK8sResourcesBadYamlDocumentFailFast(t *testing.T) {
 
 func TestGetRelevantK8sResourcesNoK8sResource(t *testing.T) {
 	dirPath := filepath.Join(getTestsDir(), "bad_yamls", "not_a_k8s_resource.yaml")
-	resFinder := newResourceFinder(NewDefaultLogger(), false, filepath.WalkDir)
+	resFinder := newResourceAccumulator(NewDefaultLogger(), false, filepath.WalkDir)
 	errs := resFinder.getRelevantK8sResources(dirPath)
 	require.Len(t, errs, 1)
 	fileErr := &FailedReadingFileError{}
@@ -56,7 +56,7 @@ func TestGetRelevantK8sResourcesNoK8sResource(t *testing.T) {
 
 func TestGetRelevantK8sResourcesNoYAMLs(t *testing.T) {
 	dirPath := filepath.Join(getTestsDir(), "bad_yamls", "subdir2")
-	resFinder := newResourceFinder(NewDefaultLogger(), false, filepath.WalkDir)
+	resFinder := newResourceAccumulator(NewDefaultLogger(), false, filepath.WalkDir)
 	errs := resFinder.getRelevantK8sResources(dirPath)
 	require.Len(t, errs, 1)
 	noYamls := &NoYamlsFoundError{}
@@ -68,7 +68,7 @@ func TestGetRelevantK8sResourcesNoYAMLs(t *testing.T) {
 
 func TestGetRelevantK8sResourcesBadDir(t *testing.T) {
 	dirPath := filepath.Join(getTestsDir(), "bad_yamls", "subdir3") // doesn't exist
-	resFinder := newResourceFinder(NewDefaultLogger(), false, filepath.WalkDir)
+	resFinder := newResourceAccumulator(NewDefaultLogger(), false, filepath.WalkDir)
 	errs := resFinder.getRelevantK8sResources(dirPath)
 	require.Len(t, errs, 1)
 	badDir := &FailedAccessingDirError{}
@@ -80,7 +80,7 @@ func TestGetRelevantK8sResourcesBadDir(t *testing.T) {
 
 func TestGetRelevantK8sResourcesBadDirFailFast(t *testing.T) {
 	dirPath := filepath.Join(getTestsDir(), "bad_yamls", "subdir3") // doesn't exist
-	resFinder := newResourceFinder(NewDefaultLogger(), true, filepath.WalkDir)
+	resFinder := newResourceAccumulator(NewDefaultLogger(), true, filepath.WalkDir)
 	errs := resFinder.getRelevantK8sResources(dirPath)
 	require.Len(t, errs, 1)
 	badDir := &FailedAccessingDirError{}
@@ -92,14 +92,14 @@ func TestGetRelevantK8sResourcesBadDirFailFast(t *testing.T) {
 
 func TestGetRelevantK8sResourcesNonK8sResources(t *testing.T) {
 	dirPath := filepath.Join(getTestsDir(), "bookinfo")
-	resFinder := newResourceFinder(NewDefaultLogger(), false, filepath.WalkDir)
+	resFinder := newResourceAccumulator(NewDefaultLogger(), false, filepath.WalkDir)
 	errs := resFinder.getRelevantK8sResources(dirPath)
 	require.Empty(t, errs) // Irrelevant resources such as Certificate are only reported to log - not returned as errors
 }
 
 func TestSearchForManifests(t *testing.T) {
 	dirPath := filepath.Join(getTestsDir(), "bad_yamls")
-	resFinder := newResourceFinder(NewDefaultLogger(), false, filepath.WalkDir)
+	resFinder := newResourceAccumulator(NewDefaultLogger(), false, filepath.WalkDir)
 	yamlFiles, errs := resFinder.searchForManifests(dirPath)
 	require.Empty(t, errs)
 	require.Len(t, yamlFiles, 5)
@@ -120,7 +120,7 @@ func nonRecursiveWalk(root string, fn fs.WalkDirFunc) error {
 
 func TestSearchForManifestsNonRecursiveWalk(t *testing.T) {
 	dirPath := filepath.Join(getTestsDir(), "bad_yamls")
-	resFinder := newResourceFinder(NewDefaultLogger(), false, nonRecursiveWalk)
+	resFinder := newResourceAccumulator(NewDefaultLogger(), false, nonRecursiveWalk)
 	yamlFiles, errs := resFinder.searchForManifests(dirPath)
 	require.Empty(t, errs)
 	require.Len(t, yamlFiles, 4)

--- a/pkg/analyzer/resource_accumulator_test.go
+++ b/pkg/analyzer/resource_accumulator_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestParseK8sYamlBadYamlDocument(t *testing.T) {
 	badYamlPath := filepath.Join(getTestsDir(), "bad_yamls", "document_with_syntax_error.yaml")
-	resAcc := newResourceAccumulator(NewDefaultLogger(), false, filepath.WalkDir)
+	resAcc := newResourceAccumulator(NewDefaultLogger(), false)
 	errs := resAcc.parseK8sYaml(badYamlPath)
 	require.Len(t, errs, 1)
 	badFile := &FailedReadingFileError{}
@@ -29,7 +29,7 @@ func TestParseK8sYamlBadYamlDocument(t *testing.T) {
 
 func TestParseK8sYamlBadYamlDocumentFailFast(t *testing.T) {
 	badYamlPath := filepath.Join(getTestsDir(), "bad_yamls", "document_with_syntax_error.yaml")
-	resAcc := newResourceAccumulator(NewDefaultLogger(), true, filepath.WalkDir)
+	resAcc := newResourceAccumulator(NewDefaultLogger(), true)
 	errs := resAcc.parseK8sYaml(badYamlPath)
 	require.Len(t, errs, 1)
 	badFile := &FailedReadingFileError{}
@@ -42,7 +42,7 @@ func TestParseK8sYamlBadYamlDocumentFailFast(t *testing.T) {
 
 func TestParseK8sYamlNoK8sResource(t *testing.T) {
 	yamlPath := filepath.Join(getTestsDir(), "bad_yamls", "not_a_k8s_resource.yaml")
-	resAcc := newResourceAccumulator(NewDefaultLogger(), false, filepath.WalkDir)
+	resAcc := newResourceAccumulator(NewDefaultLogger(), false)
 	errs := resAcc.parseK8sYaml(yamlPath)
 	require.Len(t, errs, 1)
 	fileErr := &FailedReadingFileError{}
@@ -54,7 +54,7 @@ func TestParseK8sYamlNoK8sResource(t *testing.T) {
 
 func TestParseK8sYamlNotYAML(t *testing.T) {
 	dirPath := filepath.Join(getTestsDir(), "..", ".gitignore")
-	resAcc := newResourceAccumulator(NewDefaultLogger(), false, filepath.WalkDir)
+	resAcc := newResourceAccumulator(NewDefaultLogger(), false)
 	errs := resAcc.parseK8sYaml(dirPath)
 	require.Len(t, errs, 1)
 	noYamls := &FailedReadingFileError{}
@@ -66,7 +66,7 @@ func TestParseK8sYamlNotYAML(t *testing.T) {
 
 func TestParseK8sYamlNoSuchFile(t *testing.T) {
 	dirPath := filepath.Join(getTestsDir(), "bad_yamls", "no_such_file") // doesn't exist
-	resAcc := newResourceAccumulator(NewDefaultLogger(), false, filepath.WalkDir)
+	resAcc := newResourceAccumulator(NewDefaultLogger(), false)
 	errs := resAcc.parseK8sYaml(dirPath)
 	require.Len(t, errs, 1)
 	badDir := &FailedReadingFileError{}
@@ -78,7 +78,7 @@ func TestParseK8sYamlNoSuchFile(t *testing.T) {
 
 func TestParseK8sYamlNonK8sResources(t *testing.T) {
 	dirPath := filepath.Join(getTestsDir(), "bookinfo", "bookinfo-certificate.yaml")
-	resAcc := newResourceAccumulator(NewDefaultLogger(), false, filepath.WalkDir)
+	resAcc := newResourceAccumulator(NewDefaultLogger(), false)
 	errs := resAcc.parseK8sYaml(dirPath)
 	require.Empty(t, errs) // Irrelevant resources such as Certificate are only reported to log - not returned as errors
 }

--- a/pkg/analyzer/resource_accumulator_test.go
+++ b/pkg/analyzer/resource_accumulator_test.go
@@ -8,8 +8,6 @@ package analyzer
 
 import (
 	"errors"
-	"io/fs"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -18,110 +16,81 @@ import (
 
 func TestGetRelevantK8sResourcesBadYamlDocument(t *testing.T) {
 	dirPath := filepath.Join(getTestsDir(), "bad_yamls", "document_with_syntax_error.yaml")
-	resFinder := newResourceAccumulator(NewDefaultLogger(), false, filepath.WalkDir)
-	errs := resFinder.getRelevantK8sResources(dirPath)
+	resAcc := newResourceAccumulator(NewDefaultLogger(), false, filepath.WalkDir)
+	errs := resAcc.getRelevantK8sResources(dirPath)
 	require.Len(t, errs, 1)
 	badFile := &FailedReadingFileError{}
 	require.True(t, errors.As(errs[0].Error(), &badFile))
 
-	require.Len(t, resFinder.workloads, 3)
-	require.Len(t, resFinder.services, 3)
-	require.Empty(t, resFinder.configmaps)
+	require.Len(t, resAcc.workloads, 3)
+	require.Len(t, resAcc.services, 3)
+	require.Empty(t, resAcc.configmaps)
 }
 
 func TestGetRelevantK8sResourcesBadYamlDocumentFailFast(t *testing.T) {
 	dirPath := filepath.Join(getTestsDir(), "bad_yamls", "document_with_syntax_error.yaml")
-	resFinder := newResourceAccumulator(NewDefaultLogger(), true, filepath.WalkDir)
-	errs := resFinder.getRelevantK8sResources(dirPath)
+	resAcc := newResourceAccumulator(NewDefaultLogger(), true, filepath.WalkDir)
+	errs := resAcc.getRelevantK8sResources(dirPath)
 	require.Len(t, errs, 1)
 	badFile := &FailedReadingFileError{}
 	require.True(t, errors.As(errs[0].Error(), &badFile))
 
-	require.Empty(t, resFinder.workloads)
-	require.Empty(t, resFinder.services)
-	require.Empty(t, resFinder.configmaps)
+	require.Empty(t, resAcc.workloads)
+	require.Empty(t, resAcc.services)
+	require.Empty(t, resAcc.configmaps)
 }
 
 func TestGetRelevantK8sResourcesNoK8sResource(t *testing.T) {
 	dirPath := filepath.Join(getTestsDir(), "bad_yamls", "not_a_k8s_resource.yaml")
-	resFinder := newResourceAccumulator(NewDefaultLogger(), false, filepath.WalkDir)
-	errs := resFinder.getRelevantK8sResources(dirPath)
+	resAcc := newResourceAccumulator(NewDefaultLogger(), false, filepath.WalkDir)
+	errs := resAcc.getRelevantK8sResources(dirPath)
 	require.Len(t, errs, 1)
 	fileErr := &FailedReadingFileError{}
 	require.True(t, errors.As(errs[0].Error(), &fileErr))
-	require.Empty(t, resFinder.workloads)
-	require.Len(t, resFinder.services, 1)
-	require.Empty(t, resFinder.configmaps)
+	require.Empty(t, resAcc.workloads)
+	require.Len(t, resAcc.services, 1)
+	require.Empty(t, resAcc.configmaps)
 }
 
 func TestGetRelevantK8sResourcesNoYAMLs(t *testing.T) {
 	dirPath := filepath.Join(getTestsDir(), "bad_yamls", "subdir2")
-	resFinder := newResourceAccumulator(NewDefaultLogger(), false, filepath.WalkDir)
-	errs := resFinder.getRelevantK8sResources(dirPath)
+	resAcc := newResourceAccumulator(NewDefaultLogger(), false, filepath.WalkDir)
+	errs := resAcc.getRelevantK8sResources(dirPath)
 	require.Len(t, errs, 1)
 	noYamls := &NoYamlsFoundError{}
 	require.True(t, errors.As(errs[0].Error(), &noYamls))
-	require.Empty(t, resFinder.workloads)
-	require.Empty(t, resFinder.services)
-	require.Empty(t, resFinder.configmaps)
+	require.Empty(t, resAcc.workloads)
+	require.Empty(t, resAcc.services)
+	require.Empty(t, resAcc.configmaps)
 }
 
 func TestGetRelevantK8sResourcesBadDir(t *testing.T) {
 	dirPath := filepath.Join(getTestsDir(), "bad_yamls", "subdir3") // doesn't exist
-	resFinder := newResourceAccumulator(NewDefaultLogger(), false, filepath.WalkDir)
-	errs := resFinder.getRelevantK8sResources(dirPath)
+	resAcc := newResourceAccumulator(NewDefaultLogger(), false, filepath.WalkDir)
+	errs := resAcc.getRelevantK8sResources(dirPath)
 	require.Len(t, errs, 1)
 	badDir := &FailedAccessingDirError{}
 	require.True(t, errors.As(errs[0].Error(), &badDir))
-	require.Empty(t, resFinder.workloads)
-	require.Empty(t, resFinder.services)
-	require.Empty(t, resFinder.configmaps)
+	require.Empty(t, resAcc.workloads)
+	require.Empty(t, resAcc.services)
+	require.Empty(t, resAcc.configmaps)
 }
 
 func TestGetRelevantK8sResourcesBadDirFailFast(t *testing.T) {
 	dirPath := filepath.Join(getTestsDir(), "bad_yamls", "subdir3") // doesn't exist
-	resFinder := newResourceAccumulator(NewDefaultLogger(), true, filepath.WalkDir)
-	errs := resFinder.getRelevantK8sResources(dirPath)
+	resAcc := newResourceAccumulator(NewDefaultLogger(), true, filepath.WalkDir)
+	errs := resAcc.getRelevantK8sResources(dirPath)
 	require.Len(t, errs, 1)
 	badDir := &FailedAccessingDirError{}
 	require.True(t, errors.As(errs[0].Error(), &badDir))
-	require.Empty(t, resFinder.workloads)
-	require.Empty(t, resFinder.services)
-	require.Empty(t, resFinder.configmaps)
+	require.Empty(t, resAcc.workloads)
+	require.Empty(t, resAcc.services)
+	require.Empty(t, resAcc.configmaps)
 }
 
 func TestGetRelevantK8sResourcesNonK8sResources(t *testing.T) {
 	dirPath := filepath.Join(getTestsDir(), "bookinfo")
-	resFinder := newResourceAccumulator(NewDefaultLogger(), false, filepath.WalkDir)
-	errs := resFinder.getRelevantK8sResources(dirPath)
+	resAcc := newResourceAccumulator(NewDefaultLogger(), false, filepath.WalkDir)
+	errs := resAcc.getRelevantK8sResources(dirPath)
 	require.Empty(t, errs) // Irrelevant resources such as Certificate are only reported to log - not returned as errors
-}
-
-func TestSearchForManifests(t *testing.T) {
-	dirPath := filepath.Join(getTestsDir(), "bad_yamls")
-	resFinder := newResourceAccumulator(NewDefaultLogger(), false, filepath.WalkDir)
-	yamlFiles, errs := resFinder.searchForManifests(dirPath)
-	require.Empty(t, errs)
-	require.Len(t, yamlFiles, 5)
-}
-
-func nonRecursiveWalk(root string, fn fs.WalkDirFunc) error {
-	err := filepath.WalkDir(root, func(path string, f os.DirEntry, err error) error {
-		if err != nil {
-			return filepath.SkipDir
-		}
-		if f == nil || path != root && f.IsDir() {
-			return filepath.SkipDir
-		}
-		return fn(path, f, err)
-	})
-	return err
-}
-
-func TestSearchForManifestsNonRecursiveWalk(t *testing.T) {
-	dirPath := filepath.Join(getTestsDir(), "bad_yamls")
-	resFinder := newResourceAccumulator(NewDefaultLogger(), false, nonRecursiveWalk)
-	yamlFiles, errs := resFinder.searchForManifests(dirPath)
-	require.Empty(t, errs)
-	require.Len(t, yamlFiles, 4)
 }

--- a/pkg/analyzer/utils.go
+++ b/pkg/analyzer/utils.go
@@ -6,6 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package analyzer
 
+import "path/filepath"
+
 func stopProcessing(stopOn1stErr bool, errs []FileProcessingError) bool {
 	for idx := range errs {
 		if errs[idx].IsFatal() || stopOn1stErr && errs[idx].IsSevere() {
@@ -20,4 +22,17 @@ func appendAndLogNewError(errs []FileProcessingError, newErr *FileProcessingErro
 	logError(logger, newErr)
 	errs = append(errs, *newErr)
 	return errs
+}
+
+// returns a file path without its prefix base dir
+func pathWithoutBaseDir(path, baseDir string) string {
+	if path == baseDir { // baseDir is actually a file...
+		return filepath.Base(path) // return just the file name
+	}
+
+	relPath, err := filepath.Rel(baseDir, path)
+	if err != nil {
+		return path
+	}
+	return relPath
 }

--- a/pkg/analyzer/utils.go
+++ b/pkg/analyzer/utils.go
@@ -6,8 +6,6 @@ SPDX-License-Identifier: Apache-2.0
 
 package analyzer
 
-import "path/filepath"
-
 func stopProcessing(stopOn1stErr bool, errs []FileProcessingError) bool {
 	for idx := range errs {
 		if errs[idx].IsFatal() || stopOn1stErr && errs[idx].IsSevere() {
@@ -22,17 +20,4 @@ func appendAndLogNewError(errs []FileProcessingError, newErr *FileProcessingErro
 	logError(logger, newErr)
 	errs = append(errs, *newErr)
 	return errs
-}
-
-// returns a file path without its prefix base dir
-func pathWithoutBaseDir(path, baseDir string) string {
-	if path == baseDir { // baseDir is actually a file...
-		return filepath.Base(path) // return just the file name
-	}
-
-	relPath, err := filepath.Rel(baseDir, path)
-	if err != nil {
-		return path
-	}
-	return relPath
 }


### PR DESCRIPTION
The old `ResourceFinder` class was split into two new classes:
* `manifestFinder` deals only with scanning file-system directories for yaml files
* `resourceAccumulator` deals mainly with parsing `Info` objects into internal structs, which are then being accumulated and further processed. `Info` objects can be given directly in a slice, or rather be extracted from YAML files using `fsscanner.GetResourceInfosFromDirPath`.