### PR TITLE
A method to return a slice of pointers to encountered errors

### DIFF
--- a/pkg/analyzer/policies_synthesizer.go
+++ b/pkg/analyzer/policies_synthesizer.go
@@ -95,6 +95,16 @@ func (ps *PoliciesSynthesizer) Errors() []FileProcessingError {
 	return ps.errors
 }
 
+// ErrorPtrs returns a slice of pointers to FileProcessingError with all warnings and errors encountered during processing.
+// Might be easier to use than Errors() if the returned slice is to be used as a slice of interfaces.
+func (ps *PoliciesSynthesizer) ErrorPtrs() []*FileProcessingError {
+	ret := make([]*FileProcessingError, len(ps.errors))
+	for idx := range ps.errors {
+		ret[idx] = &ps.errors[idx]
+	}
+	return ret
+}
+
 // PoliciesFromInfos returns a slice of Kubernetes NetworkPolicies that allow only the connections discovered
 // while processing K8s resources in the given slice of Info objects.
 func (ps *PoliciesSynthesizer) PoliciesFromInfos(infos []*resource.Info) ([]*networking.NetworkPolicy, error) {

--- a/pkg/analyzer/policies_synthesizer_test.go
+++ b/pkg/analyzer/policies_synthesizer_test.go
@@ -153,6 +153,8 @@ func TestPoliciesSynthesizerAPIFailFast(t *testing.T) {
 	require.Len(t, synthesizer.Errors(), 1)
 	badYaml := &FailedReadingFileError{}
 	require.True(t, errors.As(synthesizer.Errors()[0].Error(), &badYaml))
+	require.Len(t, synthesizer.ErrorPtrs(), 1)
+	require.True(t, errors.As(synthesizer.ErrorPtrs()[0].Error(), &badYaml))
 	require.Empty(t, netpols)
 }
 


### PR DESCRIPTION
Currently we only return a slice of error structs, which is harder to convert to a slice of interfaces.