### PR TITLE
Improved search for network addresses within a given string

### DIFF
--- a/cmd/nettop/main_test.go
+++ b/cmd/nettop/main_test.go
@@ -138,6 +138,15 @@ var (
 			[]string{"qotd", "expected_netpol_output.json"},
 		},
 		{
+			"CronJobWithNontrivialNetworkAddresses",
+			[][]string{{"openshift", "openshift-operator-lifecycle-manager-resources.yaml"}},
+			yamlFormat,
+			true,
+			[]string{"-v"},
+			false,
+			[]string{"openshift", "expected_netpol_output.yaml"},
+		},
+		{
 			"SpecifyDNSPort",
 			[][]string{{"acs-security-demos"}},
 			yamlFormat,

--- a/pkg/analyzer/info_to_resource_test.go
+++ b/pkg/analyzer/info_to_resource_test.go
@@ -27,6 +27,7 @@ func TestNetworkAddressValue(t *testing.T) {
 		strings.Repeat("abc", 500):      {"", false},
 		"not%a*url":                     {"", false},
 		"123":                           {"", false},
+		"olm-operator-heap-:https://olm-operator-metrics:8443/debug/pprof/heap": {"olm-operator-metrics:8443", true},
 	}
 
 	for val, expectedAnswer := range valuesToCheck {
@@ -53,8 +54,9 @@ func TestScanningDeploymentWithArgs(t *testing.T) {
 	res, err := k8sWorkloadObjectFromInfo(resourceInfo)
 	require.Nil(t, err)
 	require.Equal(t, "carts", res.Resource.Name)
-	require.Len(t, res.Resource.NetworkAddrs, 1)
-	require.Equal(t, "carts-db:27017", res.Resource.NetworkAddrs[0])
+	require.Len(t, res.Resource.NetworkAddrs, 2)
+	require.Equal(t, "false", res.Resource.NetworkAddrs[0])
+	require.Equal(t, "carts-db:27017", res.Resource.NetworkAddrs[1])
 	require.Len(t, res.Resource.Labels, 1)
 	require.Equal(t, "carts", res.Resource.Labels["name"])
 }
@@ -124,7 +126,7 @@ func TestScanningCronJob(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, "collect-profiles", res.Resource.Name)
 	require.Equal(t, cronJob, res.Resource.Kind)
-	require.Len(t, res.Resource.NetworkAddrs, 1)
+	require.Len(t, res.Resource.NetworkAddrs, 3)
 	require.Len(t, res.Resource.Labels, 0)
 }
 

--- a/pkg/analyzer/info_to_resource_test.go
+++ b/pkg/analyzer/info_to_resource_test.go
@@ -28,6 +28,8 @@ func TestNetworkAddressValue(t *testing.T) {
 		"not%a*url":                     {"", false},
 		"123":                           {"", false},
 		"olm-operator-heap-:https://olm-operator-metrics:8443/debug/pprof/heap": {"olm-operator-metrics:8443", true},
+		"-server=my-server:5024":  {"my-server:5024", true},
+		"-server=my-server:502%4": {"", false}, // port number is invalid
 	}
 
 	for val, expectedAnswer := range valuesToCheck {

--- a/tests/openshift/expected_netpol_output.yaml
+++ b/tests/openshift/expected_netpol_output.yaml
@@ -1,0 +1,97 @@
+apiVersion: networking.k8s.io/v1
+items:
+    - apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        creationTimestamp: null
+        name: catalog-operator-netpol
+        namespace: openshift-operator-lifecycle-manager
+      spec:
+        ingress:
+            - from:
+                - podSelector: {}
+              ports:
+                - port: 8443
+                  protocol: TCP
+        podSelector:
+            matchLabels:
+                app: catalog-operator
+        policyTypes:
+            - Ingress
+            - Egress
+    - apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        creationTimestamp: null
+        name: collect-profiles-netpol
+        namespace: openshift-operator-lifecycle-manager
+      spec:
+        egress:
+            - ports:
+                - port: 8443
+                  protocol: TCP
+              to:
+                - podSelector:
+                    matchLabels:
+                        app: catalog-operator
+            - ports:
+                - port: 8443
+                  protocol: TCP
+              to:
+                - podSelector:
+                    matchLabels:
+                        app: olm-operator
+            - ports:
+                - port: 53
+                  protocol: UDP
+              to:
+                - namespaceSelector: {}
+        podSelector: {}
+        policyTypes:
+            - Ingress
+            - Egress
+    - apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        creationTimestamp: null
+        name: olm-operator-netpol
+        namespace: openshift-operator-lifecycle-manager
+      spec:
+        ingress:
+            - from:
+                - podSelector: {}
+              ports:
+                - port: 8443
+                  protocol: TCP
+        podSelector:
+            matchLabels:
+                app: olm-operator
+        policyTypes:
+            - Ingress
+            - Egress
+    - apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        creationTimestamp: null
+        name: packageserver-netpol
+        namespace: openshift-operator-lifecycle-manager
+      spec:
+        podSelector:
+            matchLabels:
+                app: packageserver
+        policyTypes:
+            - Ingress
+            - Egress
+    - apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        creationTimestamp: null
+        name: default-deny-in-namespace-openshift-operator-lifecycle-manager
+        namespace: openshift-operator-lifecycle-manager
+      spec:
+        podSelector: {}
+        policyTypes:
+            - Ingress
+            - Egress
+kind: NetworkPolicyList
+metadata: {}


### PR DESCRIPTION
Fixes #353 

Also checks various suffixes of the given string to see if they can be interpreted as a network address. Starts from the whole string, then checks shorter and shorter suffixes.

This comes to identify network addresses in command-line args like `-server-addr=my_server:5000` or `server-addr:my_server:5000`.

Since we now find more suspects, a validation of the port number/name was also added, to rule-out strings that are clearly not network addresses.