### PR TITLE
allow setting a non-default **named** dns port

### DIFF
--- a/pkg/analyzer/policies_synthesizer.go
+++ b/pkg/analyzer/policies_synthesizer.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 
 	networking "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/cli-runtime/pkg/resource"
 )
 
@@ -34,7 +35,7 @@ type PoliciesSynthesizer struct {
 	logger      Logger
 	stopOnError bool
 	walkFn      WalkFunction
-	dnsPort     int
+	dnsPort     intstr.IntOrString
 
 	errors []FileProcessingError
 }
@@ -67,10 +68,17 @@ func WithStopOnError() PoliciesSynthesizerOption {
 	}
 }
 
-// WithDNSPort is a functional option to set the DNS port in the generated policies to a non-default value
+// WithDNSPort is a functional option to set the DNS port in the generated policies to a non-default integer value
 func WithDNSPort(dnsPort int) PoliciesSynthesizerOption {
 	return func(p *PoliciesSynthesizer) {
-		p.dnsPort = dnsPort
+		p.dnsPort = intstr.FromInt(dnsPort)
+	}
+}
+
+// WithDNSNamedPort is a functional option to set the DNS port in the generated policies to a specific named port
+func WithDNSNamedPort(dnsPort string) PoliciesSynthesizerOption {
+	return func(p *PoliciesSynthesizer) {
+		p.dnsPort = intstr.FromString(dnsPort)
 	}
 }
 
@@ -81,7 +89,7 @@ func NewPoliciesSynthesizer(options ...PoliciesSynthesizerOption) *PoliciesSynth
 		logger:      NewDefaultLogger(),
 		stopOnError: false,
 		walkFn:      filepath.WalkDir,
-		dnsPort:     DefaultDNSPort,
+		dnsPort:     intstr.FromInt(DefaultDNSPort),
 		errors:      []FileProcessingError{},
 	}
 	for _, o := range options {

--- a/pkg/analyzer/policies_synthesizer_test.go
+++ b/pkg/analyzer/policies_synthesizer_test.go
@@ -131,6 +131,26 @@ func TestPoliciesSynthesizerAPIDnsPort(t *testing.T) {
 	}
 }
 
+func TestPoliciesSynthesizerAPIDnsNamedPort(t *testing.T) {
+	dirPath := filepath.Join(getTestsDir(), "acs-security-demos")
+	synthesizer := NewPoliciesSynthesizer(WithDNSNamedPort("dns"))
+	netpols, err := synthesizer.PoliciesFromFolderPaths([]string{dirPath})
+	require.Nilf(t, err, "expected no fatal errors, but got %v", err)
+	require.Empty(t, synthesizer.Errors())
+	require.Len(t, netpols, 14)
+	for _, netpol := range netpols {
+		for r := range netpol.Spec.Egress {
+			eRule := &netpol.Spec.Egress[r]
+			for p := range eRule.Ports {
+				port := &eRule.Ports[p]
+				if *port.Protocol == core.ProtocolUDP {
+					require.Equal(t, "dns", port.Port.StrVal)
+				}
+			}
+		}
+	}
+}
+
 func TestPoliciesSynthesizerAPIFatalError(t *testing.T) {
 	dirPath1 := filepath.Join(getTestsDir(), "k8s_wordpress_example")
 	dirPath2 := filepath.Join(getTestsDir(), "badPath")

--- a/pkg/analyzer/synth_netpols.go
+++ b/pkg/analyzer/synth_netpols.go
@@ -186,7 +186,7 @@ func (ps *PoliciesSynthesizer) buildNetpolPerDeployment(deployConnectivity []*de
 	for _, deployConn := range deployConnectivity {
 		if len(deployConn.egressConns) > 0 { // add a rule to allow egress DNS traffic (inside the cluster)
 			allClusterPeers := []network.NetworkPolicyPeer{{NamespaceSelector: &metaV1.LabelSelector{}}}
-			deployConn.addEgressRule(allClusterPeers, []network.NetworkPolicyPort{getDNSPort(ps.dnsPort)})
+			deployConn.addEgressRule(allClusterPeers, []network.NetworkPolicyPort{getDNSPort(&ps.dnsPort)})
 		}
 		netpol := network.NetworkPolicy{
 			TypeMeta: metaV1.TypeMeta{
@@ -209,12 +209,11 @@ func (ps *PoliciesSynthesizer) buildNetpolPerDeployment(deployConnectivity []*de
 	return netpols
 }
 
-func getDNSPort(portNum int) network.NetworkPolicyPort {
+func getDNSPort(portNum *intstr.IntOrString) network.NetworkPolicyPort {
 	udp := core.ProtocolUDP
-	port := intstr.FromInt(portNum)
 	return network.NetworkPolicyPort{
 		Protocol: &udp,
-		Port:     &port,
+		Port:     portNum,
 	}
 }
 


### PR DESCRIPTION
Adding a new functional option `WithDNSNamedPort(dnsPort string)`, allowing setting the DNS port to a named port.